### PR TITLE
Encode notes to reduce transfer size/time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +417,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1617,6 +1653,7 @@ dependencies = [
 name = "noshtastic-sync"
 version = "0.1.0"
 dependencies = [
+ "brotli",
  "hex",
  "log",
  "negentropy 0.4.3 (git+https://github.com/ksedgwic/rust-negentropy.git?rev=ec19dbb4947fa7b0fbf900405a92bde504598ed1)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
  "bech32",
  "ewebsock",
  "hex",
- "nostr",
+ "nostr 0.37.0",
  "nostrdb",
  "serde",
  "serde_derive",
@@ -1621,8 +1621,11 @@ dependencies = [
  "log",
  "negentropy 0.4.3 (git+https://github.com/ksedgwic/rust-negentropy.git?rev=ec19dbb4947fa7b0fbf900405a92bde504598ed1)",
  "noshtastic-link",
+ "nostr 0.38.0",
  "nostrdb",
  "prost",
+ "secp256k1",
+ "serde_json",
  "thiserror 2.0.9",
  "tokio",
  "tonic",
@@ -1649,6 +1652,32 @@ name = "nostr"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aad4b767bbed24ac5eb4465bfb83bc1210522eb99d67cf4e547ec2ec7e47786"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bech32",
+ "bip39",
+ "bitcoin",
+ "cbc",
+ "chacha20",
+ "chacha20poly1305",
+ "getrandom",
+ "instant",
+ "negentropy 0.3.1",
+ "negentropy 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+ "url",
+]
+
+[[package]]
+name = "nostr"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7c1eebe17dd785e52e1f81149c1b50fa6ec92e4ac239840934d1ffbd4f631c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/noshtastic-link/src/lib.rs
+++ b/noshtastic-link/src/lib.rs
@@ -102,20 +102,6 @@ impl LinkMessage {
     }
 }
 
-// impl From<Vec<u8>> for LinkMessage {
-//     fn from(buffer: Vec<u8>) -> Self {
-//         LinkMessage { data: buffer }
-//     }
-// }
-
-// impl From<meshtastic::protobufs::FromRadio> for LinkMessage {
-//     fn from(from_radio: meshtastic::protobufs::FromRadio) -> Self {
-//         LinkMessage {
-//             data: from_radio.encode_to_vec(),
-//         }
-//     }
-// }
-
 impl From<LinkMsg> for LinkMessage {
     fn from(msg: LinkMsg) -> Self {
         LinkMessage {

--- a/noshtastic-link/src/lib.rs
+++ b/noshtastic-link/src/lib.rs
@@ -41,15 +41,13 @@ pub enum Priority {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
-    Replace, // replace any matches, use their place in the queue
-    Drop,    // drop this msg if a match is already queued
-    Queue,   // ignore matches, just queue
+    Drop,  // drop this msg if a match is already queued
+    Queue, // ignore matches, just queue
 }
 
 impl fmt::Display for Action {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let description = match self {
-            Action::Replace => "Replace",
             Action::Drop => "Drop",
             Action::Queue => "Queue",
         };

--- a/noshtastic-link/src/outgoing.rs
+++ b/noshtastic-link/src/outgoing.rs
@@ -76,15 +76,6 @@ impl Outgoing {
             Priority::High => &mut queues.high,
         };
         let outcome = match options.action {
-            Action::Replace => {
-                if let Some(pos) = queue.iter().position(|(id, _)| *id == msgid) {
-                    queue[pos] = (msgid, frame); // Replace the old element
-                    Action::Replace
-                } else {
-                    queue.push_back((msgid, frame)); // If no match, just enqueue
-                    Action::Queue
-                }
-            }
             Action::Drop => {
                 if !queue.iter().any(|(id, _)| *id == msgid) {
                     queue.push_back((msgid, frame)); // Enqueue only if no match

--- a/noshtastic-link/src/outgoing.rs
+++ b/noshtastic-link/src/outgoing.rs
@@ -134,7 +134,7 @@ impl Outgoing {
                         {
                             let mut link = slinkref.lock().await;
 
-                            debug!("sending LinkFrame {} encoded sz: {}", msgid, buffer.len());
+                            debug!("sending LinkFrame {}, sz: {}", msgid, buffer.len());
                             let mut router = LinkPacketRouter {
                                 my_id: link.my_node_num.into(),
                             };
@@ -166,7 +166,8 @@ impl Outgoing {
                             }
                         }
 
-                        // don't send packets back-to-back
+                        // IMPORTANT - it's important not to overload the mesh
+                        // network.  Don't send packets back-to-back!
                         sleep(Duration::from_secs(5)).await;
                     }
                     None => {

--- a/noshtastic-link/src/outgoing.rs
+++ b/noshtastic-link/src/outgoing.rs
@@ -159,7 +159,7 @@ impl Outgoing {
 
                         // IMPORTANT - it's important not to overload the mesh
                         // network.  Don't send packets back-to-back!
-                        sleep(Duration::from_secs(5)).await;
+                        sleep(Duration::from_secs(10)).await;
                     }
                     None => {
                         drop(queues);

--- a/noshtastic-link/src/serial.rs
+++ b/noshtastic-link/src/serial.rs
@@ -19,7 +19,7 @@ use tokio::{
 };
 
 use crate::{
-    outgoing::Outgoing, proto::LinkMissing, Action, FragmentCache, LinkError, LinkFrag, LinkFrame,
+    outgoing::Outgoing, proto::LinkMissing, FragmentCache, LinkError, LinkFrag, LinkFrame,
     LinkMessage, LinkMsg, LinkOptionsBuilder, LinkRef, LinkResult, MeshtasticLink, MsgId, Payload,
     Priority,
 };
@@ -193,10 +193,7 @@ impl SerialLink {
                 .enqueue(
                     msgid,
                     link_frame,
-                    LinkOptionsBuilder::new()
-                        .priority(Priority::High)
-                        .action(Action::Replace)
-                        .build(),
+                    LinkOptionsBuilder::new().priority(Priority::High).build(),
                 )
                 .await;
             debug!(
@@ -303,10 +300,7 @@ impl SerialLink {
                 .enqueue(
                     msgid,
                     link_frame,
-                    LinkOptionsBuilder::new()
-                        .priority(Priority::High)
-                        .action(Action::Replace)
-                        .build(),
+                    LinkOptionsBuilder::new().priority(Priority::High).build(),
                 )
                 .await;
             debug!(

--- a/noshtastic-link/src/serial.rs
+++ b/noshtastic-link/src/serial.rs
@@ -224,7 +224,7 @@ impl SerialLink {
         if let Some(mesh_packet::PayloadVariant::Decoded(ref decoded)) = mesh_packet.payload_variant
         {
             if decoded.portnum() == PortNum::PrivateApp {
-                debug!("received LinkFrame, encoded sz: {}", decoded.payload.len());
+                debug!("received LinkFrame, sz: {}", decoded.payload.len());
                 match LinkFrame::decode(&*decoded.payload) {
                     Ok(link_frame) => Self::handle_link_frame(linkref, link_frame).await,
                     Err(err) => error!("Failed to decode LinkFrame: {:?}", err),

--- a/noshtastic-sync/Cargo.toml
+++ b/noshtastic-sync/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true }
 tonic = { workspace = true }
 
 # unique dependencies
+brotli = "7.0"
 negentropy = { git = "https://github.com/ksedgwic/rust-negentropy.git", rev = "ec19dbb4947fa7b0fbf900405a92bde504598ed1", features = ["tiny-frame"] }
 nostr = "0.38"
 secp256k1 = "0.29"

--- a/noshtastic-sync/Cargo.toml
+++ b/noshtastic-sync/Cargo.toml
@@ -20,6 +20,9 @@ tonic = { workspace = true }
 
 # unique dependencies
 negentropy = { git = "https://github.com/ksedgwic/rust-negentropy.git", rev = "ec19dbb4947fa7b0fbf900405a92bde504598ed1", features = ["tiny-frame"] }
+nostr = "0.38"
+secp256k1 = "0.29"
+serde_json = "1.0"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/noshtastic-sync/protos/sync.proto
+++ b/noshtastic-sync/protos/sync.proto
@@ -7,8 +7,9 @@ message SyncMessage {
   oneof payload {
     Ping ping = 2;
     Pong pong = 3;
-    RawNote raw_note = 4;
-    NegentropyMessage negentropy = 5;
+    NegentropyMessage negentropy = 4;
+    RawNote raw_note = 5;
+    EncNote enc_note = 6;
   }
 }
 
@@ -20,10 +21,33 @@ message Pong {
   uint32 id = 1;
 }
 
+message NegentropyMessage {
+  bytes data = 1;
+}
+
+// utf8 encoded json
 message RawNote {
   bytes data = 1;
 }
 
-message NegentropyMessage {
-  bytes data = 1;
+message EncNote {
+  bytes id = 1;
+  bytes pubkey = 2;
+  uint64 created_at = 3;
+  uint32 kind = 4;
+  repeated EncTag tags = 5;
+  string content = 6;
+  bytes sig = 7;
+}
+
+message EncTag {
+  repeated EncString elements = 1;
+}
+
+// used when the string might be a lower-case hex string (or not)
+message EncString {
+  oneof string_type {
+    string utf8_string = 1;   // utf8 string
+    bytes hex_encoded = 2;    // Hex-encoded data stored as bytes
+  }
 }

--- a/noshtastic-sync/protos/sync.proto
+++ b/noshtastic-sync/protos/sync.proto
@@ -36,7 +36,7 @@ message EncNote {
   uint64 created_at = 3;
   uint32 kind = 4;
   repeated EncTag tags = 5;
-  string content = 6;
+  EncString content = 6;
   bytes sig = 7;
 }
 
@@ -49,5 +49,6 @@ message EncString {
   oneof string_type {
     string utf8_string = 1;   // utf8 string
     bytes hex_encoded = 2;    // Hex-encoded data stored as bytes
+    bytes compressed = 3;
   }
 }

--- a/noshtastic-sync/src/encoded_note.rs
+++ b/noshtastic-sync/src/encoded_note.rs
@@ -3,10 +3,12 @@
 // GNU General Public License, version 3 or later. See the LICENSE file
 // or <https://www.gnu.org/licenses/> for details.
 
+use brotli::{CompressorWriter, DecompressorWriter};
 use nostr::{self, JsonUtil};
 use secp256k1;
 use std::convert::TryFrom;
 use std::fmt;
+use std::io::Write;
 
 use crate::{EncNote, EncString, EncTag, StringType, SyncError};
 
@@ -29,7 +31,7 @@ impl TryFrom<nostr::event::Event> for EncNote {
             created_at: evt.created_at.as_u64(),
             kind: (evt.kind.as_u16()) as u32,
             tags: evt.tags.into_iter().map(EncTag::from).collect(),
-            content: evt.content,
+            content: Some(encode_maybe_hex_string(&evt.content)),
             sig: evt.sig.serialize().to_vec(),
         })
     }
@@ -60,7 +62,10 @@ impl TryFrom<EncNote> for nostr::event::Event {
             .into_iter()
             .map(nostr::event::Tag::try_from)
             .collect::<Result<Vec<nostr::event::Tag>, _>>()?;
-        let content = note.content;
+        let content = note
+            .content
+            .map(|enc_string| EncString::to_string(&enc_string))
+            .unwrap_or("".to_string());
         let sig = secp256k1::schnorr::Signature::from_slice(&note.sig)?;
         Ok(nostr::event::Event::new(
             id, pubkey, created_at, kind, tags, content, sig,
@@ -101,10 +106,34 @@ fn is_valid_hex_lowercase(s: &str) -> Option<Vec<u8>> {
     hex::decode(s).ok()
 }
 
+fn compress_brotli(input: &str) -> Vec<u8> {
+    let mut compressed = Vec::new();
+    {
+        let mut compressor = CompressorWriter::new(&mut compressed, 4096, 11, 22);
+        compressor.write_all(input.as_bytes()).unwrap();
+    }
+    compressed
+}
+
+fn decompress_brotli(input: &[u8]) -> String {
+    let mut decompressed = Vec::new();
+    {
+        let mut decompressor = DecompressorWriter::new(&mut decompressed, 4096);
+        decompressor.write_all(input).unwrap();
+    }
+    String::from_utf8(decompressed).unwrap()
+}
+
 fn encode_maybe_hex_string(input: &str) -> EncString {
     if let Some(hex_bytes) = is_valid_hex_lowercase(input) {
         EncString {
             string_type: Some(StringType::HexEncoded(hex_bytes)),
+        }
+    } else if input.len() > 50 {
+        // Compress if input is longer than 50 bytes
+        let compressed = compress_brotli(input);
+        EncString {
+            string_type: Some(StringType::Compressed(compressed)),
         }
     } else {
         EncString {
@@ -118,6 +147,10 @@ impl fmt::Display for EncString {
         match &self.string_type {
             Some(StringType::Utf8String(s)) => write!(f, "{}", s),
             Some(StringType::HexEncoded(b)) => write!(f, "{}", hex::encode(b)),
+            Some(StringType::Compressed(b)) => {
+                let decompressed = decompress_brotli(b);
+                write!(f, "{}", decompressed)
+            }
             None => write!(f, ""),
         }
     }
@@ -130,50 +163,127 @@ mod tests {
     use prost::Message;
     use std::convert::TryInto;
 
+    // the test notes are pretty printed, but use compact json for size metrics
+    fn compact_json(pretty_json: &str) -> String {
+        let value: serde_json::Value = serde_json::from_str(pretty_json).expect("Invalid JSON");
+        serde_json::to_string(&value).expect("Failed to serialize JSON")
+    }
+
     #[test]
-    fn test_enc_note_conversion() {
-        let original_json = r#"{"id":"c190b74042abc315c5880a70f19defc33ec2d8418fed9dde3912a762903319ce","pubkey":"850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc","created_at":1736018180,"kind":1,"tags":[["e","0000c614a9c33ac6e967abba76e04e7948317c131f044ead6d4e03988fa3bbfd","","root"],["e","23cf75046cbf489bddd5920bfb530b30f2ff101eb67b3418711a5ecfd7154c6d"],["e","38c593a0bce380656077f0a5fcbd142cb1d0f82e3d4d42015ce7e6a81e4499a9","","reply"],["p","3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],["p","ae1008d23930b776c18092f6eab41e4b09fcf3f03f3641b1b4e6ee3aa166d760"],["p","850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc"]],"content":"Ah, I saw that one ... I'm trying to make one that doesn't rely on mqtt or the internet.  I'm especially concerned that if we have a bridge or gateway to internet sourced notes that we will quickly overwhelm the mesh network.  My hope is that by limiting the \"sync range\" of messages to mesh users in a specific geographic region we can avoid overwhelming the mesh.","sig":"51289738d562bebf32b87cb6bcf5aaa2bb7119a58e19031bda3b1b17bd592891742388aa0a489cd1d60d15498f492cfe54c9bf809cde4fdee9dc52936ab8371d"}"#;
+    fn test_enc_notes_conversion() {
+        let test_notes = [
+            // Longer content string:
+            r#"{
+              "id": "c190b74042abc315c5880a70f19defc33ec2d8418fed9dde3912a762903319ce",
+              "pubkey": "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc",
+              "created_at": 1736018180,
+              "kind": 1,
+              "tags": [
+                [
+                  "e",
+                  "0000c614a9c33ac6e967abba76e04e7948317c131f044ead6d4e03988fa3bbfd",
+                  "",
+                  "root"
+                ],
+                [
+                  "e",
+                  "23cf75046cbf489bddd5920bfb530b30f2ff101eb67b3418711a5ecfd7154c6d"
+                ],
+                [
+                  "e",
+                  "38c593a0bce380656077f0a5fcbd142cb1d0f82e3d4d42015ce7e6a81e4499a9",
+                  "",
+                  "reply"
+                ],
+                [
+                  "p",
+                  "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+                ],
+                [
+                  "p",
+                  "ae1008d23930b776c18092f6eab41e4b09fcf3f03f3641b1b4e6ee3aa166d760"
+                ],
+                [
+                  "p",
+                  "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc"
+                ]
+              ],
+              "content": "Ah, I saw that one ... I'm trying to make one that doesn't rely on mqtt or the internet.  I'm especially concerned that if we have a bridge or gateway to internet sourced notes that we will quickly overwhelm the mesh network.  My hope is that by limiting the \"sync range\" of messages to mesh users in a specific geographic region we can avoid overwhelming the mesh.",
+              "sig": "51289738d562bebf32b87cb6bcf5aaa2bb7119a58e19031bda3b1b17bd592891742388aa0a489cd1d60d15498f492cfe54c9bf809cde4fdee9dc52936ab8371d"
+            }"#,
+            //
+            // Empty content:
+            r#"{
+              "id": "51f56cbaa70efb98995616fe73fcbf5169de8a7d9b50140bbace6f0f30f93c6e",
+              "pubkey": "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc",
+              "created_at": 1729536636,
+              "kind": 1,
+              "tags": [
+                [
+                  "e",
+                  "278c491bc92001ce9223110bb76dc05c8b7aa30cd6bef1fa106c919249f72827",
+                  "",
+                  "root"
+                ],
+                [
+                  "p",
+                  "f147e87ccf16ed5bb3a91de5538af015410db86c41373e0b3933ae4c905cd7ff"
+                ]
+              ],
+              "content": "",
+              "sig": "b818e303b124eedcb3fc5b8aa1b4d2b49b19fa0a9be87e6761d905783c52d397adaad666d7e57be9426026bba408d28aa2e0a9272ba6b82ef22805aff63a04b1"
+            }"#,
+            //
+            // Too bad this doesn't fit in 200 ..
+            r#"{
+              "id": "3127fa5371d17771514829bd4067003dadac0f847d3055c5e4a6fd560c3467f9",
+              "pubkey": "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc",
+              "created_at": 1728398992,
+              "kind": 1,
+              "tags": [],
+              "content": "When’s Trump gonna step in and fix this hurricane with a Sharpie again? 🤔",
+              "sig": "87b1a2a49fe83afa7436917c3a38a105fbaf281f857be64e68bcdb62ad9d47790211a02ee3ac1f8ca33b05f567e744593af565202e0a17e74be2e5826a206857"
+            }"#,
+            //
+            // Very short:
+            r#"{
+              "content": "Testing 4, 5, 6",
+              "created_at": 1732223844,
+              "id": "ead34ac6ce79ce4d9d512508cc00d9434a592c7ef4b767f89b6512b0640ed913",
+              "kind": 1,
+              "pubkey": "dcdc0e77fe223f3f62a476578350133ca97767927df676ca7ca7b92a413a7703",
+              "sig": "208b6f78348d922ab7cf7baf527800fb79d979864e523e99e9cbc45c48611e51df472cfad50376e744d7e575be47a87394069820284a30a2af02081a345d3bf3",
+              "tags": []
+            }"#,
+        ];
 
-        // {
-        //     "id": "c190b74042abc315c5880a70f19defc33ec2d8418fed9dde3912a762903319ce",
-        //     "pubkey": "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc",
-        //     "created_at": 1736018180,
-        //     "kind": 1,
-        //     "tags": [
-        //         ["e", "0000c614a9c33ac6e967abba76e04e7948317c131f044ead6d4e03988fa3bbfd", "", "root"],
-        //         ["e", "23cf75046cbf489bddd5920bfb530b30f2ff101eb67b3418711a5ecfd7154c6d"],
-        //         ["e", "38c593a0bce380656077f0a5fcbd142cb1d0f82e3d4d42015ce7e6a81e4499a9", "", "reply"],
-        //         ["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
-        //         ["p", "ae1008d23930b776c18092f6eab41e4b09fcf3f03f3641b1b4e6ee3aa166d760"],
-        //         ["p", "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc"]
-        //     ],
-        //     "content": "Ah, I saw that one ... I'm trying to make one that doesn't rely on mqtt or the internet.  I'm especially concerned that if we have a bridge or gateway to internet sourced notes that we will quickly overwhelm the mesh network.  My hope is that by limiting the \"sync range\" of messages to mesh users in a specific geographic region we can avoid overwhelming the mesh.",
-        //     "sig": "51289738d562bebf32b87cb6bcf5aaa2bb7119a58e19031bda3b1b17bd592891742388aa0a489cd1d60d15498f492cfe54c9bf809cde4fdee9dc52936ab8371d"
-        // }
+        for (index, original_json) in test_notes.iter().enumerate() {
+            let compacted_json = compact_json(&original_json);
+            let note = nostr::event::Event::from_json(original_json).expect("nostr event");
+            let enc_note = EncNote::try_from(note).expect("EncNote");
 
-        let note = nostr::event::Event::from_json(original_json).expect("nostr event");
+            let mut enc_buffer = Vec::new();
+            enc_note.encode(&mut enc_buffer).expect("encoded note");
+            println!(
+                "Test case {}: original size: {}, encoded size: {}",
+                index + 1,
+                compacted_json.len(),
+                enc_buffer.len()
+            );
 
-        let enc_note = EncNote::try_from(note).expect("EncNote");
+            // Convert back from EncNote to JSON
+            let event: nostr::event::Event = enc_note
+                .try_into()
+                .expect("Failed to convert from EncNote to Event");
+            let serialized_json = event.as_json();
 
-        let mut enc_buffer = Vec::new();
-        enc_note.encode(&mut enc_buffer).expect("encoded note");
-        println!(
-            "original size: {}, encoded size: {}",
-            original_json.len(),
-            enc_buffer.len(),
-        );
-
-        // Convert back from EncNote to JSON
-        let event: nostr::event::Event = enc_note
-            .try_into()
-            .expect("Failed to convert from EncNote to Event");
-        let serialized_json = event.as_json();
-
-        // Compare the original and serialized JSON
-        assert_eq!(
-            serde_json::from_str::<serde_json::Value>(original_json).unwrap(),
-            serde_json::from_str::<serde_json::Value>(&serialized_json).unwrap(),
-            "The serialized JSON does not match the original JSON"
-        );
+            // Compare the original and serialized JSON
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(original_json).unwrap(),
+                serde_json::from_str::<serde_json::Value>(&serialized_json).unwrap(),
+                "The serialized JSON does not match the original JSON for test case {}",
+                index + 1
+            );
+        }
     }
 }

--- a/noshtastic-sync/src/encoded_note.rs
+++ b/noshtastic-sync/src/encoded_note.rs
@@ -1,0 +1,179 @@
+// Copyright (C) 2025 Bonsai Software, Inc.
+// This file is part of Noshtastic, and is licensed under the
+// GNU General Public License, version 3 or later. See the LICENSE file
+// or <https://www.gnu.org/licenses/> for details.
+
+use nostr::{self, JsonUtil};
+use secp256k1;
+use std::convert::TryFrom;
+use std::fmt;
+
+use crate::{EncNote, EncString, EncTag, StringType, SyncError};
+
+impl TryFrom<&str> for EncNote {
+    type Error = SyncError;
+
+    fn try_from(event_json: &str) -> Result<Self, Self::Error> {
+        let evt = nostr::event::Event::from_json(event_json)?;
+        EncNote::try_from(evt)
+    }
+}
+
+impl TryFrom<nostr::event::Event> for EncNote {
+    type Error = SyncError;
+
+    fn try_from(evt: nostr::event::Event) -> Result<Self, Self::Error> {
+        Ok(EncNote {
+            id: evt.id.as_bytes().to_vec(),
+            pubkey: evt.pubkey.to_bytes().to_vec(),
+            created_at: evt.created_at.as_u64(),
+            kind: (evt.kind.as_u16()) as u32,
+            tags: evt.tags.into_iter().map(EncTag::from).collect(),
+            content: evt.content,
+            sig: evt.sig.serialize().to_vec(),
+        })
+    }
+}
+
+impl From<nostr::event::Tag> for EncTag {
+    fn from(tag: nostr::event::Tag) -> Self {
+        EncTag {
+            elements: tag
+                .to_vec()
+                .iter()
+                .map(|s| encode_maybe_hex_string(s))
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<EncNote> for nostr::event::Event {
+    type Error = SyncError;
+
+    fn try_from(note: EncNote) -> Result<Self, Self::Error> {
+        let id = nostr::event::id::EventId::from_slice(&note.id)?;
+        let pubkey = nostr::key::public_key::PublicKey::from_slice(&note.pubkey)?;
+        let created_at = note.created_at.into();
+        let kind = nostr::event::kind::Kind::from_u16(note.kind as u16);
+        let tags = note
+            .tags
+            .into_iter()
+            .map(nostr::event::Tag::try_from)
+            .collect::<Result<Vec<nostr::event::Tag>, _>>()?;
+        let content = note.content;
+        let sig = secp256k1::schnorr::Signature::from_slice(&note.sig)?;
+        Ok(nostr::event::Event::new(
+            id, pubkey, created_at, kind, tags, content, sig,
+        ))
+    }
+}
+
+impl TryFrom<EncTag> for nostr::event::Tag {
+    type Error = SyncError;
+
+    fn try_from(enc_tag: EncTag) -> Result<Self, Self::Error> {
+        Ok(nostr::event::Tag::parse(
+            enc_tag.elements.iter().map(|e| e.to_string()),
+        )?)
+    }
+}
+
+impl fmt::Display for EncNote {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let event: nostr::event::Event = self.clone().try_into().map_err(|_| fmt::Error)?;
+        write!(f, "{}", event.as_json())
+    }
+}
+
+fn is_valid_hex_lowercase(s: &str) -> Option<Vec<u8>> {
+    if s.is_empty() {
+        return None;
+    }
+    if s.len() % 2 != 0 {
+        return None; // Hex strings must have an even number of characters
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+    {
+        return None; // non-lowercase hex chars
+    }
+    hex::decode(s).ok()
+}
+
+fn encode_maybe_hex_string(input: &str) -> EncString {
+    if let Some(hex_bytes) = is_valid_hex_lowercase(input) {
+        EncString {
+            string_type: Some(StringType::HexEncoded(hex_bytes)),
+        }
+    } else {
+        EncString {
+            string_type: Some(StringType::Utf8String(input.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for EncString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.string_type {
+            Some(StringType::Utf8String(s)) => write!(f, "{}", s),
+            Some(StringType::HexEncoded(b)) => write!(f, "{}", hex::encode(b)),
+            None => write!(f, ""),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::serde_json;
+    use prost::Message;
+    use std::convert::TryInto;
+
+    #[test]
+    fn test_enc_note_conversion() {
+        let original_json = r#"{"id":"c190b74042abc315c5880a70f19defc33ec2d8418fed9dde3912a762903319ce","pubkey":"850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc","created_at":1736018180,"kind":1,"tags":[["e","0000c614a9c33ac6e967abba76e04e7948317c131f044ead6d4e03988fa3bbfd","","root"],["e","23cf75046cbf489bddd5920bfb530b30f2ff101eb67b3418711a5ecfd7154c6d"],["e","38c593a0bce380656077f0a5fcbd142cb1d0f82e3d4d42015ce7e6a81e4499a9","","reply"],["p","3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],["p","ae1008d23930b776c18092f6eab41e4b09fcf3f03f3641b1b4e6ee3aa166d760"],["p","850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc"]],"content":"Ah, I saw that one ... I'm trying to make one that doesn't rely on mqtt or the internet.  I'm especially concerned that if we have a bridge or gateway to internet sourced notes that we will quickly overwhelm the mesh network.  My hope is that by limiting the \"sync range\" of messages to mesh users in a specific geographic region we can avoid overwhelming the mesh.","sig":"51289738d562bebf32b87cb6bcf5aaa2bb7119a58e19031bda3b1b17bd592891742388aa0a489cd1d60d15498f492cfe54c9bf809cde4fdee9dc52936ab8371d"}"#;
+
+        // {
+        //     "id": "c190b74042abc315c5880a70f19defc33ec2d8418fed9dde3912a762903319ce",
+        //     "pubkey": "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc",
+        //     "created_at": 1736018180,
+        //     "kind": 1,
+        //     "tags": [
+        //         ["e", "0000c614a9c33ac6e967abba76e04e7948317c131f044ead6d4e03988fa3bbfd", "", "root"],
+        //         ["e", "23cf75046cbf489bddd5920bfb530b30f2ff101eb67b3418711a5ecfd7154c6d"],
+        //         ["e", "38c593a0bce380656077f0a5fcbd142cb1d0f82e3d4d42015ce7e6a81e4499a9", "", "reply"],
+        //         ["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
+        //         ["p", "ae1008d23930b776c18092f6eab41e4b09fcf3f03f3641b1b4e6ee3aa166d760"],
+        //         ["p", "850605096dbfb50b929e38a6c26c3d56c425325c85e05de29b759bc0e5d6cebc"]
+        //     ],
+        //     "content": "Ah, I saw that one ... I'm trying to make one that doesn't rely on mqtt or the internet.  I'm especially concerned that if we have a bridge or gateway to internet sourced notes that we will quickly overwhelm the mesh network.  My hope is that by limiting the \"sync range\" of messages to mesh users in a specific geographic region we can avoid overwhelming the mesh.",
+        //     "sig": "51289738d562bebf32b87cb6bcf5aaa2bb7119a58e19031bda3b1b17bd592891742388aa0a489cd1d60d15498f492cfe54c9bf809cde4fdee9dc52936ab8371d"
+        // }
+
+        let note = nostr::event::Event::from_json(original_json).expect("nostr event");
+
+        let enc_note = EncNote::try_from(note).expect("EncNote");
+
+        let mut enc_buffer = Vec::new();
+        enc_note.encode(&mut enc_buffer).expect("encoded note");
+        println!(
+            "original size: {}, encoded size: {}",
+            original_json.len(),
+            enc_buffer.len(),
+        );
+
+        // Convert back from EncNote to JSON
+        let event: nostr::event::Event = enc_note
+            .try_into()
+            .expect("Failed to convert from EncNote to Event");
+        let serialized_json = event.as_json();
+
+        // Compare the original and serialized JSON
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(original_json).unwrap(),
+            serde_json::from_str::<serde_json::Value>(&serialized_json).unwrap(),
+            "The serialized JSON does not match the original JSON"
+        );
+    }
+}

--- a/noshtastic-sync/src/error.rs
+++ b/noshtastic-sync/src/error.rs
@@ -22,11 +22,26 @@ pub enum SyncError {
     #[error("sync: link error: {0}")]
     LinkError(#[from] noshtastic_link::LinkError),
 
+    #[error("sync: nostr event error: {0}")]
+    NostrEventError(#[from] nostr::event::Error),
+
+    #[error("sync: nostr event id error: {0}")]
+    NostrEventIdError(#[from] nostr::event::id::Error),
+
+    #[error("sync: nostr event tag error: {0}")]
+    NostrEventTagError(#[from] nostr::event::tag::Error),
+
+    #[error("sync: nostr key error: {0}")]
+    NostrEventKeyError(#[from] nostr::key::Error),
+
     #[error("sync: nostrdb error: {0}")]
     NostrdbError(#[from] nostrdb::Error),
 
     #[error("sync: negentropy error: {0}")]
     NegentropyError(#[from] negentropy::Error),
+
+    #[error("sync: secp256k1 error: {0}")]
+    Secp256k1Error(#[from] secp256k1::Error),
 }
 
 impl SyncError {

--- a/noshtastic-sync/src/lib.rs
+++ b/noshtastic-sync/src/lib.rs
@@ -3,6 +3,7 @@
 // GNU General Public License, version 3 or later. See the LICENSE file
 // or <https://www.gnu.org/licenses/> for details.
 
+pub mod encoded_note;
 pub mod error;
 pub mod lruset;
 pub mod negentropy;
@@ -15,5 +16,7 @@ pub use error::*;
 pub use lruset::LruSet;
 pub use proto::sync_message::Payload;
 pub use proto::SyncMessage;
-pub use proto::{NegentropyMessage, Ping, Pong, RawNote};
+pub use proto::{
+    enc_string::StringType, EncNote, EncString, EncTag, NegentropyMessage, Ping, Pong, RawNote,
+};
 pub use sync::Sync;

--- a/noshtastic-sync/src/negentropy.rs
+++ b/noshtastic-sync/src/negentropy.rs
@@ -24,7 +24,7 @@ impl NegentropyState {
         let txn = nostrdb::Transaction::new(&self.ndb)?;
         let filters = vec![Filter::new().kinds([1]).build()];
         let notes = self.ndb.query(&txn, &filters, 1024)?;
-        debug!("inserting {} notes into negentropy state", notes.len());
+        debug!("composing negentropy state with {} notes", notes.len());
         for note in notes {
             match self.ndb.get_note_by_key(&txn, note.note_key) {
                 Err(err) => error!("trouble getting note {:?}: {:?}", note.note_key, err),

--- a/noshtastic-sync/src/sync.rs
+++ b/noshtastic-sync/src/sync.rs
@@ -21,7 +21,7 @@ use noshtastic_link::{
 };
 
 use crate::{
-    negentropy::NegentropyState, LruSet, NegentropyMessage, Payload, Ping, Pong, RawNote,
+    negentropy::NegentropyState, EncNote, LruSet, NegentropyMessage, Payload, Ping, Pong, RawNote,
     SyncError, SyncMessage, SyncResult,
 };
 
@@ -140,7 +140,7 @@ impl Sync {
                     debug!("suppressing send of recently inserted {}", msgid);
                 } else {
                     dbg!(&note_json);
-                    self.send_raw_note(MsgId::from_nostr_msgid(note.id()), &note_json)?;
+                    self.send_encoded_note(MsgId::from_nostr_msgid(note.id()), &note_json)?;
                 }
             }
             Err(err) => error!("error in get_note_by_key: {:?}", err),
@@ -193,6 +193,10 @@ impl Sync {
                 info!("received RawNote {} sz: {}", msgid, raw_note.data.len());
                 sync.handle_raw_note(msgid, raw_note);
             }
+            Some(Payload::EncNote(enc_note)) => {
+                info!("received EncNote {}", msgid);
+                sync.handle_enc_note(msgid, enc_note);
+            }
             Some(Payload::Negentropy(negmsg)) => {
                 info!("received NegentropyMessage sz: {}", negmsg.data.len());
                 let mut have_ids = vec![];
@@ -225,12 +229,27 @@ impl Sync {
         if let Ok(utf8_str) = std::str::from_utf8(&raw_note.data) {
             debug!("saw RawNote {}: {}", msgid, utf8_str);
             if let Err(err) = self.ndb.process_client_event(utf8_str) {
-                error!("ndb process_client_event failed: {}: {:?}", &utf8_str, err);
+                error!(
+                    "ndb process_client_event (raw) failed: {}: {:?}",
+                    &utf8_str, err
+                );
             }
             self.recently_inserted.insert(msgid);
         } else {
             debug!("saw RawNote: [Invalid UTF-8 data: {:x?}]", raw_note.data);
         }
+    }
+
+    fn handle_enc_note(&mut self, msgid: MsgId, enc_note: EncNote) {
+        let utf8_str = enc_note.to_string();
+        debug!("saw EncNote {}: {}", msgid, utf8_str);
+        if let Err(err) = self.ndb.process_client_event(&utf8_str) {
+            error!(
+                "ndb process_client_event (enc) failed: {}: {:?}",
+                &utf8_str, err
+            );
+        }
+        self.recently_inserted.insert(msgid);
     }
 
     pub fn after_delay<F, T>(syncref: Arc<Mutex<T>>, delay: Duration, task: F)
@@ -294,8 +313,8 @@ impl Sync {
                     Err(err) => error!("trouble in get_note_by_id: {:?}", err),
                     Ok(note) => {
                         if let Ok(note_json) = note.json() {
-                            if let Err(err) =
-                                self.send_raw_note(MsgId::from_nostr_msgid(note.id()), &note_json)
+                            if let Err(err) = self
+                                .send_encoded_note(MsgId::from_nostr_msgid(note.id()), &note_json)
                             {
                                 error!("trouble queueing needed raw note: {:?}", err);
                                 // keep going
@@ -328,12 +347,18 @@ impl Sync {
         )
     }
 
-    fn send_raw_note(&self, msgid: MsgId, note_json: &str) -> SyncResult<()> {
-        info!("queueing RawNote {} sz: {}", msgid, note_json.len());
-        let raw_note = Payload::RawNote(RawNote {
-            data: note_json.as_bytes().to_vec(),
-        });
-        self.queue_outgoing_message(msgid, Some(raw_note), LinkOptionsBuilder::new().build())
+    // fn send_raw_note(&self, msgid: MsgId, note_json: &str) -> SyncResult<()> {
+    //     info!("queueing RawNote {} sz: {}", msgid, note_json.len());
+    //     let raw_note = Payload::RawNote(RawNote {
+    //         data: note_json.as_bytes().to_vec(),
+    //     });
+    //     self.queue_outgoing_message(msgid, Some(raw_note), LinkOptionsBuilder::new().build())
+    // }
+
+    fn send_encoded_note(&self, msgid: MsgId, note_json: &str) -> SyncResult<()> {
+        info!("queueing EncNote {} sz: {}", msgid, note_json.len());
+        let enc_note = Payload::EncNote(EncNote::try_from(note_json)?);
+        self.queue_outgoing_message(msgid, Some(enc_note), LinkOptionsBuilder::new().build())
     }
 
     fn send_ping(&self, ping_id: u32) -> SyncResult<()> {


### PR DESCRIPTION
- Original sample message was 1167 bytes.
- After using protobuf for the outer nostr framing (NIP-01) and binary encoding for id, pubkey, sig was 953 bytes.
- Converting any "standalone" hex string values (tags) to binary encoding yields 793 bytes.
- Using brotli compression on content bodies results in 612 bytes.
