### PR TITLE
Workaround unsendable fragments by rotating the data

### DIFF
--- a/noshtastic-link/protos/link.proto
+++ b/noshtastic-link/protos/link.proto
@@ -24,7 +24,8 @@ message LinkFrag {
   fixed64 msgid = 1;		// Truncated nostr msgid (or hash for others)
   uint32 numfrag = 2;   	// Total number of fragments in the packet
   uint32 fragndx = 3;		// Index of this fragment (starting at 0)
-  bytes data = 4;		// Raw data buffer for this fragment
+  uint32 rotoff = 4;		// Octet rotation offset (see noshtastic:#15)
+  bytes data = 5;		// Raw data buffer for this fragment
 }
 
 // A missing fragment resend request

--- a/noshtastic-sync/src/encoded_note.rs
+++ b/noshtastic-sync/src/encoded_note.rs
@@ -258,7 +258,7 @@ mod tests {
         ];
 
         for (index, original_json) in test_notes.iter().enumerate() {
-            let compacted_json = compact_json(&original_json);
+            let compacted_json = compact_json(original_json);
             let note = nostr::event::Event::from_json(original_json).expect("nostr event");
             let enc_note = EncNote::try_from(note).expect("EncNote");
 

--- a/noshtastic-sync/src/negentropy.rs
+++ b/noshtastic-sync/src/negentropy.rs
@@ -6,6 +6,7 @@
 use log::*;
 use negentropy::{Bytes, Id, Negentropy, NegentropyStorageVector};
 use nostrdb::{Filter, Ndb};
+use std::io::Write;
 
 use crate::SyncResult;
 
@@ -48,7 +49,9 @@ impl NegentropyState {
         debug!("initiate starting");
         let mut negentropy = self.compose_negentropy()?;
         let negmsg = negentropy.initiate()?;
+        Self::writeln_stdio("------------------- INITIATING QUERY -------------------");
         negentropy.dump_query(&negmsg, std::io::stdout())?;
+        Self::writeln_stdio("--------------------------------------------------------");
         Ok(negmsg.to_bytes())
     }
 
@@ -60,7 +63,9 @@ impl NegentropyState {
     ) -> SyncResult<Option<Vec<u8>>> {
         debug!("reconcile starting");
         let mut negentropy = self.compose_negentropy()?;
+        Self::writeln_stdio("----------------- RECEIVED THEIR QUERY -----------------");
         negentropy.dump_query(&Bytes::from_slice(inmsg), std::io::stdout())?;
+        Self::writeln_stdio("--------------------------------------------------------");
         negentropy.set_initiator();
         let mut have_ids_tmp: Vec<negentropy::Id> = Vec::new();
         let mut need_ids_tmp: Vec<negentropy::Id> = Vec::new();
@@ -78,8 +83,14 @@ impl NegentropyState {
             .map(|id| id.to_bytes().to_vec())
             .collect();
         if let Some(negmsg) = &maybe_negmsg {
+            Self::writeln_stdio("----------------- SENDING OUR RESPONSE -----------------");
             negentropy.dump_query(negmsg, std::io::stdout())?;
+            Self::writeln_stdio("--------------------------------------------------------");
         }
         Ok(maybe_negmsg.map(|bytes| bytes.to_vec()))
+    }
+
+    fn writeln_stdio(line: &str) {
+        writeln!(std::io::stdout(), "{}", line).ok();
     }
 }


### PR DESCRIPTION
See #15 for more information.

Each octet of the message is "rotated" by adding (mod256) a `rotoff` value which is sent in the fragment header.  The receiver reverses the rotation.

Fixes #15 