### PR TITLE
Use multifilter-compat hack to enable use with multifilter clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,8 +1726,7 @@ dependencies = [
 [[package]]
 name = "nostr"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d3f2f0d564cce3ebe09bb1343af67d88c60108cedc518a307dfdf6e3f503b6"
+source = "git+https://github.com/ksedgwic/nostr?rev=64eb8ca861996b66e9821dd8b53316453a518074#64eb8ca861996b66e9821dd8b53316453a518074"
 dependencies = [
  "base64",
  "bech32",
@@ -1744,10 +1749,9 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6dc456a11d26f99a932b6531d94c20cb2e274ada6eab1d2438e2fb9c944af5"
+source = "git+https://github.com/ksedgwic/nostr?rev=64eb8ca861996b66e9821dd8b53316453a518074#64eb8ca861996b66e9821dd8b53316453a518074"
 dependencies = [
- "lru",
+ "lru 0.14.0",
  "nostr",
  "tokio",
 ]
@@ -1755,8 +1759,7 @@ dependencies = [
 [[package]]
 name = "nostr-ndb"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd635b914b167437cb1f3b20fd256068f2fc9d622d9e05dfd13f0b097e81b609"
+source = "git+https://github.com/ksedgwic/nostr?rev=64eb8ca861996b66e9821dd8b53316453a518074#64eb8ca861996b66e9821dd8b53316453a518074"
 dependencies = [
  "nostr",
  "nostr-database",
@@ -1766,8 +1769,7 @@ dependencies = [
 [[package]]
 name = "nostr-relay-builder"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7846558d9aadaf2e6ec1f8d12dd94a7e8c61d9cb799b80b3c2affc7f1e214dc6"
+source = "git+https://github.com/ksedgwic/nostr?rev=64eb8ca861996b66e9821dd8b53316453a518074#64eb8ca861996b66e9821dd8b53316453a518074"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -1788,7 +1790,7 @@ dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
- "lru",
+ "lru 0.13.0",
  "negentropy 0.3.1",
  "negentropy 0.5.0",
  "nostr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,19 @@ chrono = "0.4"
 env_logger = "0.11"
 hex = "0.4"
 log = "0.4"
-nostr = "0.41"
-nostr-relay-builder = "0.41"
+#nostr = "0.41"
+#nostr-relay-builder = "0.41"
+nostr = { git = "https://github.com/ksedgwic/nostr", rev = "64eb8ca861996b66e9821dd8b53316453a518074" }
+nostr-relay-builder = { git = "https://github.com/ksedgwic/nostr", rev = "64eb8ca861996b66e9821dd8b53316453a518074", features = ["multifilter-compat"] }
 nostrdb = "0.6"
 prost = "0.11"
 serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.42", features = ["full"] }
 tracing = { version = "0.1", features = ["log", "log-always"] }
+
+[patch.crates-io]
+nostr        = { git = "https://github.com/ksedgwic/nostr", rev = "64eb8ca861996b66e9821dd8b53316453a518074" }
+nostr-relay-builder = { git = "https://github.com/ksedgwic/nostr", rev = "64eb8ca861996b66e9821dd8b53316453a518074" }
+nostr-ndb    = { git = "https://github.com/ksedgwic/nostr", rev = "64eb8ca861996b66e9821dd8b53316453a518074" }
+nostr-database = { git = "https://github.com/ksedgwic/nostr", rev = "64eb8ca861996b66e9821dd8b53316453a518074" }

--- a/crates/noshtastic-link/src/outgoing.rs
+++ b/crates/noshtastic-link/src/outgoing.rs
@@ -229,13 +229,11 @@ pub(crate) struct LinkPacketRouter {
 }
 
 impl PacketRouter<(), LinkError> for LinkPacketRouter {
-    fn handle_packet_from_radio(&mut self, packet: FromRadio) -> Result<(), LinkError> {
-        dbg!(packet);
+    fn handle_packet_from_radio(&mut self, _packet: FromRadio) -> Result<(), LinkError> {
         Ok(())
     }
 
-    fn handle_mesh_packet(&mut self, packet: MeshPacket) -> Result<(), LinkError> {
-        dbg!(packet);
+    fn handle_mesh_packet(&mut self, _packet: MeshPacket) -> Result<(), LinkError> {
         Ok(())
     }
 

--- a/crates/noshtastic-sync/src/sync.rs
+++ b/crates/noshtastic-sync/src/sync.rs
@@ -294,7 +294,7 @@ impl Sync {
 
     fn handle_raw_note(&mut self, msgid: MsgId, raw_note: RawNote) {
         if let Ok(utf8_str) = std::str::from_utf8(&raw_note.data) {
-            info!("saw RawNote {}: {}", msgid, utf8_str);
+            debug!("saw RawNote {}: {}", msgid, utf8_str);
 
             // first, store it in the db
             if let Err(err) = self
@@ -318,7 +318,7 @@ impl Sync {
 
     fn handle_enc_note(&mut self, msgid: MsgId, enc_note: EncNote) {
         let utf8_str = enc_note.to_string();
-        info!("saw EncNote {}: {}", msgid, utf8_str);
+        debug!("saw EncNote {}: {}", msgid, utf8_str);
 
         // first, store it in the db
         if let Err(err) = self

--- a/crates/noshtastic-sync/src/sync.rs
+++ b/crates/noshtastic-sync/src/sync.rs
@@ -190,7 +190,6 @@ impl Sync {
                     // from the mesh
                     debug!("suppressing send of recently inserted {}", msgid);
                 } else {
-                    dbg!(&note_json);
                     self.send_encoded_note(MsgId::from_nostr_msgid(note.id()), &note_json)?;
                 }
             }

--- a/crates/noshtastic-testgw/src/lib.rs
+++ b/crates/noshtastic-testgw/src/lib.rs
@@ -126,7 +126,6 @@ mod tests {
             })
             .collect();
         let filter = Filter::new().authors(authors.iter()).kinds([1]).build();
-        dbg!(authors);
         assert_eq!(
             filter.json().unwrap(),
             r#"{"authors":["379e863e8357163b5bce5d2688dc4f1dcc2d505222fb8d74db600f30535dfdfe"],"kinds":[1]}"#


### PR DESCRIPTION
This is not ideal, instead of Noshtastic returning errors to Amethyst we attempt to mash the multiple filters into a single filter.  Maybe ok for super simple cases ... not a good long term solution.