### PR TITLE
Scale bandwidth limits and policy scheduling by modem preset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "meshtastic"
 version = "0.1.6"
-source = "git+https://github.com/ksedgwic/meshtastic-rust?rev=e7351477df915ba285e3bfeb7b135553066e9062#e7351477df915ba285e3bfeb7b135553066e9062"
+source = "git+https://github.com/ksedgwic/meshtastic-rust?rev=67d5d869a4f648645890099f1947cec2545f2a8f#67d5d869a4f648645890099f1947cec2545f2a8f"
 dependencies = [
  "btleplug",
  "futures",

--- a/crates/noshtastic-android/src/android.rs
+++ b/crates/noshtastic-android/src/android.rs
@@ -365,7 +365,7 @@ async fn setup_noshtastic(radio_name: &str) -> Result<()> {
     let stop_signal = Arc::new(Notify::new());
     let maybe_hint = Some(radio_name.to_string());
 
-    let (linkref, link_tx, link_rx) =
+    let (link_config, linkref, link_tx, link_rx) =
         noshtastic_link::create_link(&maybe_hint, stop_signal.clone())
             .await
             .context("create_link failed")?;
@@ -378,6 +378,7 @@ async fn setup_noshtastic(radio_name: &str) -> Result<()> {
     let (incoming_event_tx, incoming_event_rx) = mpsc::unbounded_channel::<String>();
 
     let syncref = Sync::new(
+        link_config,
         ndb.clone(),
         link_tx,
         link_rx,

--- a/crates/noshtastic-android/src/android.rs
+++ b/crates/noshtastic-android/src/android.rs
@@ -378,7 +378,7 @@ async fn setup_noshtastic(radio_name: &str) -> Result<()> {
     let (incoming_event_tx, incoming_event_rx) = mpsc::unbounded_channel::<String>();
 
     let syncref = Sync::new(
-        link_config,
+        &link_config,
         ndb.clone(),
         link_tx,
         link_rx,

--- a/crates/noshtastic-cli/src/main.rs
+++ b/crates/noshtastic-cli/src/main.rs
@@ -135,7 +135,7 @@ async fn main() -> Result<()> {
     let (incoming_event_tx, incoming_event_rx) = mpsc::unbounded_channel::<String>();
 
     let syncref = Sync::new(
-        link_config,
+        &link_config,
         ndb.clone(),
         link_tx,
         link_rx,

--- a/crates/noshtastic-cli/src/main.rs
+++ b/crates/noshtastic-cli/src/main.rs
@@ -126,7 +126,8 @@ async fn main() -> Result<()> {
     let args = build_args_with_help()?;
     let ndb = init_nostrdb(&args.data_dir)?;
     let mut testgw = TestGW::new(ndb.clone(), &args.testgw_relay, &args.testgw_filter)?;
-    let (_linkref, link_tx, link_rx) = create_link(&args.serial, stop_signal.clone()).await?;
+    let (link_config, _linkref, link_tx, link_rx) =
+        create_link(&args.serial, stop_signal.clone()).await?;
 
     // The relay doesn't see events when they arrive via the mesh and
     // are inserted in the database directly, use this channel to send
@@ -134,6 +135,7 @@ async fn main() -> Result<()> {
     let (incoming_event_tx, incoming_event_rx) = mpsc::unbounded_channel::<String>();
 
     let syncref = Sync::new(
+        link_config,
         ndb.clone(),
         link_tx,
         link_rx,

--- a/crates/noshtastic-link/Cargo.toml
+++ b/crates/noshtastic-link/Cargo.toml
@@ -18,7 +18,7 @@ sha2 = "0.10"
 tokio-serial = "5.4"
 
 # need BLE, use custom branch w/ prospective PRs
-meshtastic =  { git = "https://github.com/ksedgwic/meshtastic-rust", rev = "e7351477df915ba285e3bfeb7b135553066e9062", features = ["bluetooth-le"] }
+meshtastic =  { git = "https://github.com/ksedgwic/meshtastic-rust", rev = "67d5d869a4f648645890099f1947cec2545f2a8f", features = ["bluetooth-le"] }
 #meshtastic = { path = "../../../meshtastic-rust", features = ["bluetooth-le"] }
 
 [build-dependencies]

--- a/crates/noshtastic-link/src/lib.rs
+++ b/crates/noshtastic-link/src/lib.rs
@@ -150,7 +150,7 @@ pub async fn create_link(
     maybe_hint: &Option<String>,
     stop_signal: Arc<Notify>,
 ) -> LinkResult<(
-    Arc<LinkConfig>,
+    LinkConfig,
     LinkRef,
     mpsc::UnboundedSender<LinkMessage>,
     mpsc::UnboundedReceiver<LinkMessage>,
@@ -183,7 +183,7 @@ pub async fn create_link(
 
     // create the link
     let linkref = Arc::new(Mutex::new(Link::new(
-        link_config.clone(),
+        &link_config,
         configured_stream_api,
         client_out_tx,
         stop_signal.clone(),
@@ -236,7 +236,7 @@ impl LinkConfig {
 pub async fn wait_for_config_complete(
     decoded_listener: &mut mpsc::UnboundedReceiver<protobufs::FromRadio>,
     config_id: u32,
-) -> LinkResult<Arc<LinkConfig>> {
+) -> LinkResult<LinkConfig> {
     let mut maybe_config: Option<LinkConfig> = None;
     while let Some(packet) = decoded_listener.recv().await {
         // Check the payload_variant field
@@ -247,7 +247,7 @@ pub async fn wait_for_config_complete(
                         log::debug!("Received ConfigComplete for ID {id}, config is finished");
                         return match maybe_config {
                             None => Err(LinkError::internal_error("Missing LoRaConfig")),
-                            Some(link_cfg) => Ok(Arc::new(link_cfg)),
+                            Some(link_cfg) => Ok(link_cfg),
                         };
                     } else {
                         log::info!("Got ConfigCompleteId for {id}, but expecting {config_id}");

--- a/crates/noshtastic-link/src/lib.rs
+++ b/crates/noshtastic-link/src/lib.rs
@@ -42,7 +42,6 @@ pub struct LinkOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Priority {
-    Low,
     Normal,
     High,
 }
@@ -100,7 +99,7 @@ impl LinkOptionsBuilder {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkInfo {
-    pub qlen: [usize; 3], // lengths [high, normal, low]
+    pub qlen: [usize; 2], // lengths [high, normal]
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/noshtastic-link/src/lib.rs
+++ b/crates/noshtastic-link/src/lib.rs
@@ -150,8 +150,8 @@ pub async fn create_link(
     stop_signal: Arc<Notify>,
 ) -> LinkResult<(
     LinkRef,
-    mpsc::Sender<LinkMessage>,
-    mpsc::Receiver<LinkMessage>,
+    mpsc::UnboundedSender<LinkMessage>,
+    mpsc::UnboundedReceiver<LinkMessage>,
 )> {
     debug!("info_link starting");
 
@@ -176,9 +176,8 @@ pub async fn create_link(
     // |        rx | <------------ | tx      rx | <----------- | tx         |
     // +-----------+               +------------+              +------------+
 
-    // FIXME - change these to unbounded
-    let (client_in_tx, client_in_rx) = mpsc::channel::<LinkMessage>(100);
-    let (client_out_tx, client_out_rx) = mpsc::channel::<LinkMessage>(100);
+    let (client_in_tx, client_in_rx) = mpsc::unbounded_channel::<LinkMessage>();
+    let (client_out_tx, client_out_rx) = mpsc::unbounded_channel::<LinkMessage>();
 
     // create the link
     let linkref = Arc::new(Mutex::new(Link::new(

--- a/crates/noshtastic-link/src/link.rs
+++ b/crates/noshtastic-link/src/link.rs
@@ -35,7 +35,6 @@ const LINK_READY_HOLDOFF_SECS: u64 = 5; // wait this long after settled
 const LINK_INFO_SECS: u64 = 60; // send link info periodically
 
 pub struct Link {
-    pub(crate) _link_config: Arc<LinkConfig>,
     pub(crate) stream_api: ConnectedStreamApi,
     client_out_tx: mpsc::UnboundedSender<LinkMessage>,
     _stop_signal: Arc<Notify>,
@@ -49,19 +48,18 @@ pub type LinkRef = Arc<tokio::sync::Mutex<Link>>;
 
 impl Link {
     pub(crate) fn new(
-        _link_config: Arc<LinkConfig>,
+        link_config: &LinkConfig,
         stream_api: ConnectedStreamApi,
         client_out_tx: mpsc::UnboundedSender<LinkMessage>,
         stop_signal: Arc<Notify>,
     ) -> Self {
         Link {
-            _link_config: _link_config.clone(),
             stream_api,
             client_out_tx,
             _stop_signal: stop_signal,
             my_node_num: 0,
             fragcache: FragmentCache::new(),
-            outgoing: Outgoing::new(_link_config.clone()),
+            outgoing: Outgoing::new(link_config),
             ready_deadline: Instant::now() + Duration::from_secs(LINK_READY_HOLDOFF_SECS),
             declared_ready: false,
         }

--- a/crates/noshtastic-link/src/link.rs
+++ b/crates/noshtastic-link/src/link.rs
@@ -22,7 +22,7 @@ use tokio::{
 };
 
 use crate::{
-    outgoing::Outgoing, proto::LinkMissing, FragmentCache, LinkConfig, LinkFrag, LinkFrame,
+    outgoing::Outgoing, proto::LinkMissing, Action, FragmentCache, LinkConfig, LinkFrag, LinkFrame,
     LinkInfo, LinkMessage, LinkMsg, LinkOptionsBuilder, LinkPayload, LinkResult, MsgId, Payload,
     Priority,
 };
@@ -397,7 +397,10 @@ impl Link {
                 .enqueue(
                     msgid,
                     link_frame,
-                    LinkOptionsBuilder::new().priority(Priority::High).build(),
+                    LinkOptionsBuilder::new()
+                        .priority(Priority::High)
+                        .action(Action::Drop)
+                        .build(),
                 )
                 .await;
             info!(

--- a/crates/noshtastic-link/src/outgoing.rs
+++ b/crates/noshtastic-link/src/outgoing.rs
@@ -17,7 +17,9 @@ use tokio::{
     time::{sleep, Duration},
 };
 
-use crate::{Action, LinkError, LinkFrame, LinkOptions, LinkRef, LinkResult, MsgId, Priority};
+use crate::{
+    Action, LinkConfig, LinkError, LinkFrame, LinkOptions, LinkRef, LinkResult, MsgId, Priority,
+};
 
 const LINK_TX_RATE_LIMIT_SECS: u64 = 10;
 const LINK_OUTGOING_QUEUE_MAX: usize = 100;
@@ -50,14 +52,16 @@ impl Queues {
 
 #[derive(Debug)]
 pub(crate) struct Outgoing {
+    _link_config: Arc<LinkConfig>,
     queuesref: Arc<Mutex<Queues>>,
     notify: Option<mpsc::UnboundedSender<()>>,
 }
 
 impl Outgoing {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(_link_config: Arc<LinkConfig>) -> Self {
         let queuesref = Arc::new(Mutex::new(Queues::new()));
         Outgoing {
+            _link_config,
             queuesref,
             notify: None,
         }

--- a/crates/noshtastic-sync/src/sync.rs
+++ b/crates/noshtastic-sync/src/sync.rs
@@ -20,8 +20,8 @@ use tokio::{
 };
 
 use noshtastic_link::{
-    self, Action, LinkInfo, LinkMessage, LinkOptions, LinkOptionsBuilder, LinkPayload, MsgId,
-    Priority,
+    self, Action, LinkConfig, LinkInfo, LinkMessage, LinkOptions, LinkOptionsBuilder, LinkPayload,
+    MsgId, Priority,
 };
 
 use crate::{
@@ -35,6 +35,7 @@ const SYNC_OUTGOING_REFILL_THRESH: usize = 10;
 const SYNC_OUTGOING_PAUSE_THRESH: usize = 50;
 
 pub struct Sync {
+    _link_config: Arc<LinkConfig>,
     _stop_signal: Arc<Notify>,
     ndb: Ndb,
     link_tx: mpsc::UnboundedSender<LinkMessage>,
@@ -52,6 +53,7 @@ pub type SyncRef = Arc<std::sync::Mutex<Sync>>;
 
 impl Sync {
     pub fn new(
+        _link_config: Arc<LinkConfig>,
         ndb: Ndb,
         link_tx: mpsc::UnboundedSender<LinkMessage>,
         link_rx: mpsc::UnboundedReceiver<LinkMessage>,
@@ -60,6 +62,7 @@ impl Sync {
     ) -> SyncResult<SyncRef> {
         let long_ago = Instant::now() - Duration::from_secs(u64::MAX / 2);
         let syncref = Arc::new(Mutex::new(Sync {
+            _link_config: _link_config.clone(),
             _stop_signal: stop_signal.clone(),
             ndb: ndb.clone(),
             link_tx,


### PR DESCRIPTION
Different modem preset settings have different amounts of available bandwidth, scale our policies appropriately.