### PR TITLE
Don't build non-android things for android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,15 @@ check:
 # NOTE - the `--no-strip` below can be removed to reduce size at the
 # cost of non-symbolic backtraces
 jni: fake
-	cargo ndk --target arm64-v8a --no-strip -o $(ANDROID_DIR)/app/src/main/jniLibs/ build --profile dev
+	cargo ndk \
+	  --target arm64-v8a \
+	  --no-strip \
+	  -o $(ANDROID_DIR)/app/src/main/jniLibs/ \
+	  build \
+	  --profile dev \
+	  --workspace \
+	  --exclude noshtastic-cli \
+	  --exclude noshtastic-testgw
 
 apk: jni
 	cd $(ANDROID_DIR) && ./gradlew build

--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ regions.  For example a noshtastic relay might cover **`9q[bc89]`**
 
 ## Building
 
+### Prerequisites
+
+- Protobuf
+  * fedora: `sudo dnf install -y protobuf protobuf-c protobuf-compiler protobuf-devel`
+  * windows: `choco install protoc`
+
+- Android Studio, with Android NDK properly installed both in path and
+  with `ANDROID_HOME` and `ANDROID_NDK_HOME`
+
+- `cargo install cargo-ndk`
+
+- `rustup target install aarch64-linux-android`
+
 ### Unix CLI
 
 ```


### PR DESCRIPTION
- `noshtastic-cli` and `noshtastic-testgw` aren't needed for android