### PR TITLE
Prune negentropy traffic to generate depth-first traversal

### DIFF
--- a/crates/noshtastic-link/src/error.rs
+++ b/crates/noshtastic-link/src/error.rs
@@ -24,9 +24,15 @@ pub enum LinkError {
     MeshtasticError(#[from] meshtastic::errors::Error),
 }
 
-impl From<mpsc::error::SendError<crate::LinkMessage>> for LinkError {
-    fn from(err: mpsc::error::SendError<crate::LinkMessage>) -> Self {
-        LinkError::InternalError(format!("failed to send message via channel: {:?}", err))
+impl From<mpsc::error::SendError<crate::LinkOutMessage>> for LinkError {
+    fn from(err: mpsc::error::SendError<crate::LinkOutMessage>) -> Self {
+        LinkError::InternalError(format!("failed to send out message via channel: {:?}", err))
+    }
+}
+
+impl From<mpsc::error::SendError<crate::LinkInMessage>> for LinkError {
+    fn from(err: mpsc::error::SendError<crate::LinkInMessage>) -> Self {
+        LinkError::InternalError(format!("failed to send in message via channel: {:?}", err))
     }
 }
 

--- a/crates/noshtastic-link/src/outgoing.rs
+++ b/crates/noshtastic-link/src/outgoing.rs
@@ -18,7 +18,7 @@ use tokio::{
 };
 
 use crate::{
-    Action, LinkConfig, LinkError, LinkFrame, LinkOptions, LinkRef, LinkResult, MsgId, Priority,
+    Action, LinkConfig, LinkError, LinkFrame, LinkOutOptions, LinkRef, LinkResult, MsgId, Priority,
 };
 
 #[derive(Debug)]
@@ -101,7 +101,7 @@ impl Outgoing {
         &mut self,
         msgid: MsgId,
         frame: LinkFrame,
-        options: LinkOptions,
+        options: LinkOutOptions,
     ) -> Action {
         let mut queues = self.queuesref.lock().await;
         let need_wakeup = queues.is_empty();
@@ -127,7 +127,7 @@ impl Outgoing {
         outcome
     }
 
-    pub(crate) async fn cancel(&mut self, msgid: MsgId, options: LinkOptions) {
+    pub(crate) async fn cancel(&mut self, msgid: MsgId, options: LinkOutOptions) {
         // When the link receives a message it should cancel any
         // outgoing copies of the message (another node beat us to
         // it) ...

--- a/crates/noshtastic-link/src/outgoing.rs
+++ b/crates/noshtastic-link/src/outgoing.rs
@@ -18,7 +18,8 @@ use tokio::{
 };
 
 use crate::{
-    Action, LinkConfig, LinkError, LinkFrame, LinkOutOptions, LinkRef, LinkResult, MsgId, Priority,
+    Action, LinkConfig, LinkError, LinkFrame, LinkOutOptions, LinkRef, LinkResult, MsgId, Policy,
+    Priority,
 };
 
 #[derive(Debug)]
@@ -51,8 +52,8 @@ impl OutgoingPolicy {
 
 #[derive(Debug)]
 struct Queues {
-    normal: VecDeque<(MsgId, LinkFrame)>,
-    high: VecDeque<(MsgId, LinkFrame)>,
+    normal: VecDeque<(MsgId, Policy, LinkFrame)>,
+    high: VecDeque<(MsgId, Policy, LinkFrame)>,
 }
 
 impl Queues {
@@ -105,26 +106,55 @@ impl Outgoing {
     ) -> Action {
         let mut queues = self.queuesref.lock().await;
         let need_wakeup = queues.is_empty();
+
+        // pick normal vs high
         let queue = match options.priority {
             Priority::Normal => &mut queues.normal,
             Priority::High => &mut queues.high,
         };
-        let outcome = if queue.len() > self.policy.outgoing_queue_max {
-            Action::Limit // drop
-        } else {
-            if !queue.iter().any(|(id, _)| *id == msgid) {
-                queue.push_back((msgid, frame));
-                Action::Queue
-            } else {
-                Action::Dup // drop
-            }
-        };
-        if need_wakeup {
-            if let Err(err) = self.notify.as_ref().unwrap().send(()) {
-                error!("trouble sending notification to regulator: {:?}", err);
-            }
+
+        // 1) queue-size cap
+        if queue.len() > self.policy.outgoing_queue_max {
+            return Action::Limit;
         }
-        outcome
+
+        // 2) dedupe by msgid
+        if queue
+            .iter()
+            .any(|(existing_id, _, _)| existing_id == &msgid)
+        {
+            return Action::Dup;
+        }
+
+        // 3) classy preempt/purge
+        if let Policy::Classy(ref class, level) = options.policy {
+            // a) preempt if any same-class entry has > level, equals stays
+            if queue.iter().any(|(_, pol, _)| {
+                matches!(
+                    pol,
+                    Policy::Classy(ref c2, ref l2)
+                        if c2 == class && *l2 > level
+                )
+            }) {
+                return Action::Preempt;
+            }
+            // b) purge any same-class with lower level, equal stays
+            queue.retain(|(_, pol, _)| {
+                !matches!(
+                    pol,
+                    Policy::Classy(ref c2, ref l2)
+                        if c2 == class && *l2 < level
+                )
+            });
+        }
+
+        // 4) enqueue
+        queue.push_back((msgid, options.policy.clone(), frame));
+
+        if need_wakeup {
+            let _ = self.notify.as_ref().unwrap().send(());
+        }
+        Action::Queue
     }
 
     pub(crate) async fn cancel(&mut self, msgid: MsgId, options: LinkOutOptions) {
@@ -142,7 +172,7 @@ impl Outgoing {
 
         // Retain only those elements that do not match the given `msgid`
         let original_len = queue.len();
-        queue.retain(|(id, _)| *id != msgid);
+        queue.retain(|(id, _policy, _frame)| *id != msgid);
 
         let removed_count = original_len - queue.len();
         if removed_count > 0 {
@@ -164,7 +194,7 @@ impl Outgoing {
                     .pop_front()
                     .or_else(|| queues.normal.pop_front())
                 {
-                    Some((msgid, frame)) => {
+                    Some((msgid, _policy, frame)) => {
                         let qlens = vec![queues.high.len(), queues.normal.len()];
                         drop(queues);
 

--- a/crates/noshtastic-sync/protos/sync.proto
+++ b/crates/noshtastic-sync/protos/sync.proto
@@ -23,6 +23,7 @@ message Pong {
 
 message NegentropyMessage {
   bytes data = 1;
+  uint32 level = 2; // 0 when initialized, increment on reconcile
 }
 
 // utf8 encoded json

--- a/crates/noshtastic-sync/src/negentropy.rs
+++ b/crates/noshtastic-sync/src/negentropy.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 
 use crate::SyncResult;
 
-const SYNC_NEGENTROPY_FRAME_SIZE_LIMIT: u64 = 500;
+const SYNC_NEGENTROPY_FRAME_SIZE_LIMIT: u64 = 200;
 
 pub(crate) struct NegentropyState {
     ndb: Ndb,

--- a/crates/noshtastic-sync/src/sync.rs
+++ b/crates/noshtastic-sync/src/sync.rs
@@ -21,7 +21,7 @@ use tokio::{
 
 use noshtastic_link::{
     self, LinkConfig, LinkInMessage, LinkInfo, LinkOutMessage, LinkOutOptions,
-    LinkOutOptionsBuilder, LinkOutPayload, MsgId, Priority,
+    LinkOutOptionsBuilder, LinkOutPayload, MsgId, Policy, Priority,
 };
 
 use crate::{
@@ -497,6 +497,7 @@ impl Sync {
             Some(negmsg),
             LinkOutOptionsBuilder::new()
                 .priority(Priority::High)
+                .policy(Policy::Classy("negentropy".into(), level))
                 .build(),
         )
     }

--- a/crates/noshtastic-sync/src/sync.rs
+++ b/crates/noshtastic-sync/src/sync.rs
@@ -43,7 +43,7 @@ impl SyncPolicy {
         const BASE_DATA_KBPS: f32 = 3.52;
         const OUTGOING_REFILL_THRESH: f32 = 10.0;
         const OUTGOING_PAUSE_THRESH: f32 = 50.0;
-        const NOTE_IDLE_SECS: f32 = 120.0;
+        const NOTE_IDLE_SECS: f32 = 60.0;
         const RECONCILE_IDLE_SECS: f32 = 120.0;
 
         let queue_scale = link_cfg.data_kbps / BASE_DATA_KBPS;


### PR DESCRIPTION
Use outgoing queue preemption to prune the negentropy messages..